### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -80,7 +80,7 @@ anyio = ">=3.4.0,<5.0"
 [[package]]
 name = "autogen"
 version = "0.8.1"
-description = "Alias package for pyautogen"
+description = "Alias package for ag2"
 optional = false
 python-versions = "<3.14,>=3.9"
 groups = ["main"]
@@ -90,59 +90,59 @@ files = [
 ]
 
 [package.dependencies]
-pyautogen = "0.8.1"
+ag2 = "0.8.1"
 
 [package.extras]
-anthropic = ["pyautogen[anthropic] (==0.8.1)"]
-autobuild = ["pyautogen[autobuild] (==0.8.1)"]
-bedrock = ["pyautogen[bedrock] (==0.8.1)"]
-blendsearch = ["pyautogen[blendsearch] (==0.8.1)"]
-browser-use = ["pyautogen[browser-use] (==0.8.1)"]
-captainagent = ["pyautogen[captainagent] (==0.8.1)"]
-cerebras = ["pyautogen[cerebras] (==0.8.1)"]
-cohere = ["pyautogen[cohere] (==0.8.1)"]
-commsagent-discord = ["pyautogen[commsagent-discord] (==0.8.1)"]
-commsagent-slack = ["pyautogen[commsagent-slack] (==0.8.1)"]
-commsagent-telegram = ["pyautogen[commsagent-telegram] (==0.8.1)"]
-cosmosdb = ["pyautogen[cosmosdb] (==0.8.1)"]
-crawl4ai = ["pyautogen[crawl4ai] (==0.8.1)"]
-deepseek = ["pyautogen[deepseek] (==0.8.1)"]
-dev = ["pyautogen[dev] (==0.8.1)"]
-docs = ["pyautogen[docs] (==0.8.1)"]
-flaml = ["pyautogen[flaml] (==0.8.1)"]
-gemini = ["pyautogen[gemini] (==0.8.1)"]
-gemini-realtime = ["pyautogen[gemini-realtime] (==0.8.1)"]
-graph = ["pyautogen[graph] (==0.8.1)"]
-graph-rag-falkor-db = ["pyautogen[graph-rag-falkor-db] (==0.8.1)"]
-groq = ["pyautogen[groq] (==0.8.1)"]
-interop = ["pyautogen[interop] (==0.8.1)"]
-interop-crewai = ["pyautogen[interop-crewai] (==0.8.1)"]
-interop-langchain = ["pyautogen[interop-langchain] (==0.8.1)"]
-interop-pydantic-ai = ["pyautogen[interop-pydantic-ai] (==0.8.1)"]
-jupyter-executor = ["pyautogen[jupyter-executor] (==0.8.1)"]
-lint = ["pyautogen[lint] (==0.8.1)"]
-lmm = ["pyautogen[lmm] (==0.8.1)"]
-long-context = ["pyautogen[long-context] (==0.8.1)"]
-mathchat = ["pyautogen[mathchat] (==0.8.1)"]
-mistral = ["pyautogen[mistral] (==0.8.1)"]
-neo4j = ["pyautogen[neo4j] (==0.8.1)"]
-ollama = ["pyautogen[ollama] (==0.8.1)"]
-openai = ["pyautogen[openai] (==0.8.1)"]
-openai-realtime = ["pyautogen[openai-realtime] (==0.8.1)"]
-rag = ["pyautogen[rag] (==0.8.1)"]
-redis = ["pyautogen[redis] (==0.8.1)"]
-retrievechat = ["pyautogen[retrievechat] (==0.8.1)"]
-retrievechat-couchbase = ["pyautogen[retrievechat-couchbase] (==0.8.1)"]
-retrievechat-mongodb = ["pyautogen[retrievechat-mongodb] (==0.8.1)"]
-retrievechat-pgvector = ["pyautogen[retrievechat-pgvector] (==0.8.1)"]
-retrievechat-qdrant = ["pyautogen[retrievechat-qdrant] (==0.8.1)"]
-teachable = ["pyautogen[teachable] (==0.8.1)"]
-test = ["pyautogen[test] (==0.8.1)"]
-together = ["pyautogen[together] (==0.8.1)"]
-twilio = ["pyautogen[twilio] (==0.8.1)"]
-types = ["pyautogen[types] (==0.8.1)"]
-websockets = ["pyautogen[websockets] (==0.8.1)"]
-websurfer = ["pyautogen[websurfer] (==0.8.1)"]
+anthropic = ["ag2[anthropic] (==0.8.1)"]
+autobuild = ["ag2[autobuild] (==0.8.1)"]
+bedrock = ["ag2[bedrock] (==0.8.1)"]
+blendsearch = ["ag2[blendsearch] (==0.8.1)"]
+browser-use = ["ag2[browser-use] (==0.8.1)"]
+captainagent = ["ag2[captainagent] (==0.8.1)"]
+cerebras = ["ag2[cerebras] (==0.8.1)"]
+cohere = ["ag2[cohere] (==0.8.1)"]
+commsagent-discord = ["ag2[commsagent-discord] (==0.8.1)"]
+commsagent-slack = ["ag2[commsagent-slack] (==0.8.1)"]
+commsagent-telegram = ["ag2[commsagent-telegram] (==0.8.1)"]
+cosmosdb = ["ag2[cosmosdb] (==0.8.1)"]
+crawl4ai = ["ag2[crawl4ai] (==0.8.1)"]
+deepseek = ["ag2[deepseek] (==0.8.1)"]
+dev = ["ag2[dev] (==0.8.1)"]
+docs = ["ag2[docs] (==0.8.1)"]
+flaml = ["ag2[flaml] (==0.8.1)"]
+gemini = ["ag2[gemini] (==0.8.1)"]
+gemini-realtime = ["ag2[gemini-realtime] (==0.8.1)"]
+graph = ["ag2[graph] (==0.8.1)"]
+graph-rag-falkor-db = ["ag2[graph-rag-falkor-db] (==0.8.1)"]
+groq = ["ag2[groq] (==0.8.1)"]
+interop = ["ag2[interop] (==0.8.1)"]
+interop-crewai = ["ag2[interop-crewai] (==0.8.1)"]
+interop-langchain = ["ag2[interop-langchain] (==0.8.1)"]
+interop-pydantic-ai = ["ag2[interop-pydantic-ai] (==0.8.1)"]
+jupyter-executor = ["ag2[jupyter-executor] (==0.8.1)"]
+lint = ["ag2[lint] (==0.8.1)"]
+lmm = ["ag2[lmm] (==0.8.1)"]
+long-context = ["ag2[long-context] (==0.8.1)"]
+mathchat = ["ag2[mathchat] (==0.8.1)"]
+mistral = ["ag2[mistral] (==0.8.1)"]
+neo4j = ["ag2[neo4j] (==0.8.1)"]
+ollama = ["ag2[ollama] (==0.8.1)"]
+openai = ["ag2[openai] (==0.8.1)"]
+openai-realtime = ["ag2[openai-realtime] (==0.8.1)"]
+rag = ["ag2[rag] (==0.8.1)"]
+redis = ["ag2[redis] (==0.8.1)"]
+retrievechat = ["ag2[retrievechat] (==0.8.1)"]
+retrievechat-couchbase = ["ag2[retrievechat-couchbase] (==0.8.1)"]
+retrievechat-mongodb = ["ag2[retrievechat-mongodb] (==0.8.1)"]
+retrievechat-pgvector = ["ag2[retrievechat-pgvector] (==0.8.1)"]
+retrievechat-qdrant = ["ag2[retrievechat-qdrant] (==0.8.1)"]
+teachable = ["ag2[teachable] (==0.8.1)"]
+test = ["ag2[test] (==0.8.1)"]
+together = ["ag2[together] (==0.8.1)"]
+twilio = ["ag2[twilio] (==0.8.1)"]
+types = ["ag2[types] (==0.8.1)"]
+websockets = ["ag2[websockets] (==0.8.1)"]
+websurfer = ["ag2[websurfer] (==0.8.1)"]
 
 [[package]]
 name = "beautifulsoup4"
@@ -1157,15 +1157,15 @@ files = [
 pyasn1 = ">=0.4.6,<0.7.0"
 
 [[package]]
-name = "pyautogen"
+name = "ag2"
 version = "0.8.1"
 description = "A programming framework for agentic AI"
 optional = false
 python-versions = "<3.14,>=3.9"
 groups = ["main"]
 files = [
-    {file = "pyautogen-0.8.1-py3-none-any.whl", hash = "sha256:e630afd879583a4e505efa27d4206d255f4beae1b047d95d916768164919674d"},
-    {file = "pyautogen-0.8.1.tar.gz", hash = "sha256:4d370920e6a65349406037c8e0dab22a6ce814231fe4c68a4da9e5e236265bcb"},
+    {file = "ag2-0.8.1-py3-none-any.whl", hash = "sha256:e630afd879583a4e505efa27d4206d255f4beae1b047d95d916768164919674d"},
+    {file = "ag2-0.8.1.tar.gz", hash = "sha256:4d370920e6a65349406037c8e0dab22a6ce814231fe4c68a4da9e5e236265bcb"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.13,<3.14"
 dependencies = [
-    "pyautogen (>=0.8.1,<0.9.0)",
+    "ag2 (>=0.8.1,<0.9.0)",
     "bs4 (>=0.0.2,<0.0.3)",
     "autogen (>=0.8.1,<0.9.0)",
     "google-api-python-client (>=2.164.0,<3.0.0)",


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
